### PR TITLE
fix: use CR spec productVersion in GetImage instead of hardcoded default

### DIFF
--- a/internal/controller/cluster.go
+++ b/internal/controller/cluster.go
@@ -36,10 +36,15 @@ func NewClusterReconciler(
 }
 
 func (r *ClusterReconciler) GetImage() *util.Image {
+	productVersion := airflowv1alpha1.DefaultProductVersion
+	if r.Spec.Image.ProductVersion != "" {
+		productVersion = r.Spec.Image.ProductVersion
+	}
+
 	image := util.NewImage(
 		airflowv1alpha1.DefaultProductName,
 		airflowversion.BuildVersion,
-		airflowv1alpha1.DefaultProductVersion,
+		productVersion,
 		func(options *util.ImageOptions) {
 			options.Custom = r.Spec.Image.Custom
 			options.Repo = r.Spec.Image.Repo


### PR DESCRIPTION
## Problem

GetImage() hard-codes `DefaultProductVersion`, ignoring the CR spec's `productVersion` field. This causes mismatched image tags when deploying with a custom productVersion.

Same root cause as zookeeper-operator #348.

## Fix

Prioritize CR spec `image.productVersion` when set, falling back to `DefaultProductVersion` otherwise.