### PR TITLE
fix(ci): split chart-lint-test into chart-lint-helm and chart-e2e

### DIFF
--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -49,7 +49,7 @@ jobs:
         working-directory: deploy/helm
         run: ah lint
 
-  lint-test:
+  chart-lint-helm:
     runs-on: ubuntu-latest
     needs:
       - check-crds-sync
@@ -86,48 +86,38 @@ jobs:
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
         uses: helm/kind-action@v1.14.0
+
+      - name: Setup Go
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: actions/setup-go@v6
         with:
-          cluster_name: kind  # Default cluster name is 'chart-testing'
+          go-version-file: go.mod
+
+      - name: Build image
+        if: steps.list-changed.outputs.changed == 'true'
+        run: make docker-build
 
       - name: Load images to cluster
         if: steps.list-changed.outputs.changed == 'true'
-        run: |
-          make docker-build
-          kind load docker-image quay.io/zncdatadev/airflow-operator:$VERSION
-
+        run: kind load docker-image --name chart-testing quay.io/zncdatadev/airflow-operator:$VERSION
 
       - name: Run chart-testing (install)
-        id: ct-test
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           ct install --config ./.github/configs/ct-install.yaml
-          # Save success result to github output
-          if [[ $? -eq 0 ]]; then
-            echo "ct_tested=true" >> "$GITHUB_OUTPUT"
-          fi
 
-      - name: Build helm chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
-        run: |
-          make helm-chart-package
+  chart-e2e:
+    runs-on: ubuntu-latest
+    needs:
+      - check-crds-sync
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
 
-      - name: Run e2e with chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
-        run: |
-          HELM_DEPENDENCIES=(
-            commons-operator
-            listener-operator
-            secret-operator
-          )
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
-          # Install dependencies
-          for dep in "${HELM_DEPENDENCIES[@]}"; do
-            helm upgrade --install --create-namespace --namespace kubedoop-operators --wait $dep oci://quay.io/kubedoopcharts/$dep --version $VERSION
-          done
-
-          # Install packaged operator chart
-          helm install --create-namespace --namespace airflow-operator --wait airflow-operator ./target/charts/airflow-operator-$VERSION.tgz
-
-          # E2E tests
-          make chainsaw
-          ./bin/chainsaw test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
+      - name: Run chart-e2e
+        run: make chart-e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
         run: ah lint
 
 
-  chart-lint-test:
+  chart-lint-helm:
     runs-on: ubuntu-latest
     needs:
       - check-crds-sync
@@ -208,8 +208,16 @@ jobs:
         id: commit-range
         run: |
           # Get current and previous tag
+          # Exclude -dev pre-release tags only when looking for the previous tag,
+          # not when matching the current tag itself
           CURRENT_TAG="${{ github.ref_name }}"
-          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -A1 "^${CURRENT_TAG}$" | tail -n1)
+          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -A1 "^${CURRENT_TAG}$" | tail -n1 | grep -v '\\-dev$')
+
+          # If the -dev tag itself was the only match (no previous stable tag found),
+          # try again excluding -dev to find the actual previous stable release
+          if [[ -z "$PREVIOUS_TAG" ]]; then
+            PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -v '\\-dev$' | grep -A1 "^${CURRENT_TAG}$" | tail -n1)
+          fi
 
           # First release detection
           if [[ "$PREVIOUS_TAG" == "$CURRENT_TAG" || -z "$PREVIOUS_TAG" ]]; then
@@ -281,53 +289,45 @@ jobs:
       - name: Create kind cluster
         if: steps.check-changes.outputs.changed == 'true'
         uses: helm/kind-action@v1.14.0
+
+      - name: Setup Go
+        if: steps.check-changes.outputs.changed == 'true'
+        uses: actions/setup-go@v6
         with:
-          cluster_name: kind  # Default cluster name is 'chart-testing'
+          go-version-file: go.mod
+
+      - name: Build image
+        if: steps.check-changes.outputs.changed == 'true'
+        run: make docker-build
 
       - name: Load images to cluster
         if: steps.check-changes.outputs.changed == 'true'
-        run: |
-          make docker-build
-          kind load docker-image quay.io/zncdatadev/airflow-operator:$VERSION
+        run: kind load docker-image --name chart-testing quay.io/zncdatadev/airflow-operator:$VERSION
 
       - name: Run chart-testing (install)
-        id: ct-test
         if: steps.check-changes.outputs.changed == 'true'
         run: |
           ct install \
             --since "${{ steps.commit-range.outputs.since_commit }}" \
             --target-branch "${{ steps.commit-range.outputs.target_branch }}" \
             --config ./.github/configs/ct-install.yaml
-          # Save success result to github output
-          if [[ $? -eq 0 ]]; then
-            echo "ct_tested=true" >> "$GITHUB_OUTPUT"
-          fi
 
-      - name: Build helm chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
-        run: |
-          make helm-chart-package
 
-      - name: Run e2e with chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
-        run: |
-          HELM_DEPENDENCIES=(
-            commons-operator
-            listener-operator
-            secret-operator
-          )
+  chart-e2e:
+    runs-on: ubuntu-latest
+    needs:
+      - check-crds-sync
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
 
-          # Install dependencies
-          for dep in "${HELM_DEPENDENCIES[@]}"; do
-            helm upgrade --install --create-namespace --namespace kubedoop-operators --wait $dep oci://quay.io/kubedoopcharts/$dep --version $VERSION
-          done
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
-          # Install packaged operator chart
-          helm install --create-namespace --namespace airflow-operator --wait airflow-operator ./target/charts/airflow-operator-$VERSION.tgz
-
-          # E2E tests
-          make chainsaw
-          ./bin/chainsaw test --test-dir ./test/e2e/
+      - name: Run chart-e2e
+        run: make chart-e2e
 
 
   release-chart:
@@ -336,7 +336,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - chart-linter-artifacthub
-      - chart-lint-test
+      - chart-lint-helm
+      - chart-e2e
     steps:
       - name: Clone the code
         uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -277,8 +277,12 @@ HELM ?= helm
 helm-crd-sync: manifests kustomize ## Sync CRDs to helm chart for the operator
 	"$(KUSTOMIZE)" build config/crd > deploy/helm/$(PROJECT_NAME)/crds/crds.yaml
 
+.PHONY: chart ## Generate helm chart for the operator.
+chart: manifests kustomize ## Generate helm chart for the operator.
+	"$(KUSTOMIZE)" build config/crd > deploy/helm/$(PROJECT_NAME)/crds/crds.yaml
+
 .PHONY: helm-chart-package ## Package helm chart for the operator.
-helm-chart-package: ## Package helm chart for the operator.
+helm-chart-package: chart ## Package helm chart for the operator.
 	mkdir -p target/charts
 	rm -rf target/charts/*.tgz
 	"$(HELM)" package deploy/helm/$(PROJECT_NAME) --version $(VERSION) --app-version $(VERSION) --destination target/charts
@@ -356,3 +360,11 @@ cleanup-chainsaw-e2e: ## Run the chainsaw cleanup
 cleanup-chainsaw-cluster: ## Tear down the Kind cluster used for chainsaw e2e tests
 	$(KIND) delete cluster --name $(CHAINSAW_CLUSTER)
 	rm -f $(CHAINSAW_KUBECONFIG)
+
+.PHONY: chart-e2e
+chart-e2e: setup-chainsaw-cluster chainsaw docker-build helm-chart-package ## Run e2e tests with Helm chart deployment
+	"$(KIND)" --name $(CHAINSAW_CLUSTER) load docker-image "$(IMG)"
+	"$(HELM)" upgrade --install --create-namespace --namespace airflow-operator \
+		--kubeconfig $(CHAINSAW_KUBECONFIG) --wait $(PROJECT_NAME) \
+		target/charts/$(PROJECT_NAME)-$(VERSION).tgz
+	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/


### PR DESCRIPTION
## Summary

Align airflow-operator CI with the release baseline by splitting the monolithic `chart-lint-test` job.

## Changes

- **chart-lint-test.yml**: Split `lint-test` into `chart-lint-helm` (ct lint + install) and `chart-e2e` (chainsaw e2e via Helm chart deployment)
- **release.yml**: Same split, plus:
  - Add `check-crds-sync` job
  - Add `-dev` tag filtering in commit range detection
  - Fix kind cluster name to use default `chart-testing`
  - Add `--config` to chainsaw test command (via Makefile chart-e2e target)
  - Update `release-chart` needs to reference new job names
- **Makefile**:
  - Add `setup-chainsaw-cluster`, `helm-chart-package`, `helm-chart-publish`, `chart-e2e` targets
  - Keep `chart-publish` as deprecated alias for `helm-chart-publish`