### PR TITLE
fix(e2e): replace bash-specific double-bracket with POSIX single-bracket for /bin/sh compatibility

### DIFF
--- a/test/e2e/observability/chainsaw-test.yaml
+++ b/test/e2e/observability/chainsaw-test.yaml
@@ -87,7 +87,7 @@ spec:
 
               # Test metrics endpoint accessibility
               HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:9102/metrics)
-              if [[ "$HTTP_CODE" != "200" ]]; then
+              if [ "$HTTP_CODE" != "200" ]; then
                 echo "ERROR: Failed to access metrics endpoint, HTTP code: $HTTP_CODE"
                 kill $PF_PID 2>/dev/null || true
                 exit 1


### PR DESCRIPTION
## Summary

Replace double-bracket test with POSIX single-bracket in observability e2e test.

## Problem

Chainsaw uses /usr/bin/sh to execute scripts. On Ubuntu, /bin/sh is dash which does not support double-bracket. The condition returns exit code 127 which is treated as false, making the metrics endpoint check silently pass even on failure.