### PR TITLE
fix: update DefaultProductVersion to 2.10.5 to align with containers/airflow/versions.yaml

### DIFF
--- a/api/v1alpha1/airflowcluster_types.go
+++ b/api/v1alpha1/airflowcluster_types.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	DefaultRepository     = "quay.io/zncdatadev"
-	DefaultProductVersion = "2.10.2"
+	DefaultProductVersion = "2.10.5"
 	DefaultProductName    = "airflow"
 )
 
@@ -53,7 +53,7 @@ type ImageSpec struct {
 	KubedoopVersion string `json:"kubedoopVersion,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="2.10.2"
+	// +kubebuilder:default="2.10.5"
 	ProductVersion string `json:"productVersion,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/airflow.kubedoop.dev_airflowclusters.yaml
+++ b/config/crd/bases/airflow.kubedoop.dev_airflowclusters.yaml
@@ -499,7 +499,7 @@ spec:
                     default: 0.0.0-dev
                     type: string
                   productVersion:
-                    default: 2.10.2
+                    default: 2.10.5
                     type: string
                   pullPolicy:
                     default: IfNotPresent

--- a/deploy/helm/airflow-operator/crds/airflow.kubedoop.dev_airflowclusters.yaml
+++ b/deploy/helm/airflow-operator/crds/airflow.kubedoop.dev_airflowclusters.yaml
@@ -499,7 +499,7 @@ spec:
                     default: 0.0.0-dev
                     type: string
                   productVersion:
-                    default: 2.10.2
+                    default: 2.10.5
                     type: string
                   pullPolicy:
                     default: IfNotPresent

--- a/deploy/helm/airflow-operator/crds/crds.yaml
+++ b/deploy/helm/airflow-operator/crds/crds.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -498,7 +499,7 @@ spec:
                     default: 0.0.0-dev
                     type: string
                   productVersion:
-                    default: 2.10.2
+                    default: 2.10.5
                     type: string
                   pullPolicy:
                     default: IfNotPresent


### PR DESCRIPTION
## Summary

Update `DefaultProductVersion` from `2.10.2` to `2.10.5` to align with `zncdata-containers/airflow/versions.yaml`.

### Problem
The current default `2.10.2` is not available in the containers project:
- Available versions in `zncdata-containers/airflow/versions.yaml`: `3.0.1`, `2.10.5`, `2.10.4`
- Operator default: `2.10.2` ❌ (no matching image)

### Changes
- `DefaultProductVersion` constant: `2.10.2` → `2.10.5`
- `+kubebuilder:default` annotation: `2.10.2` → `2.10.5`
- Regenerated CRD manifests (productVersion default updated)
- Helm CRDs synced with generated CRDs