### PR TITLE
ci: catch untracked generated files in check-crds-sync

### DIFF
--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -27,8 +27,11 @@ jobs:
         run: |
           # Use `make manifests` to generate the CRDs
           make manifests
-          # Check if the CRDs are in sync with the manifests
-          if ! git diff --exit-code; then
+          # Check if the CRDs are in sync with the manifests.
+          # Stage everything first so newly generated (untracked) files are
+          # detected too; plain `git diff` ignores untracked files.
+          git add -A
+          if ! git diff --cached --exit-code; then
             echo "CRDs are not in sync with the manifests."
             echo "Please run 'make manifests' to update the CRDs."
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,8 +155,11 @@ jobs:
         run: |
           # Use `make manifests` to generate the CRDs
           make manifests
-          # Check if the CRDs are in sync with the manifests
-          if ! git diff --exit-code; then
+          # Check if the CRDs are in sync with the manifests.
+          # Stage everything first so newly generated (untracked) files are
+          # detected too; plain `git diff` ignores untracked files.
+          git add -A
+          if ! git diff --cached --exit-code; then
             echo "CRDs are not in sync with the manifests."
             echo "Please run 'make manifests' to update the CRDs."
             exit 1


### PR DESCRIPTION
## What

The `check-crds-sync` job runs `make manifests` and then `git diff --exit-code`, but `git diff` only reports changes to **tracked** files. A brand-new generated CRD/RBAC file that was never committed is untracked, so it passed the gate silently — stale-by-omission escaped CI.

This stages everything first and diffs the index instead, so untracked generated files fail the check too:

```sh
make manifests
git add -A
if ! git diff --cached --exit-code; then
```

Applied to the `check-crds-sync` job in both `chart-lint-test.yml` and `release.yml`.

## Why it's safe

- `git add -A` respects `.gitignore`, so the `bin/` tooling downloaded by `make manifests` does not trip the check (`bin` is gitignored in this repo).
- Verified in a scratch repo: the old check misses an untracked generated file; the new check catches it; a clean tree with only ignored `bin/` content still passes.

Part of an org-wide rollout of the same fix to all operator repos with this job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
